### PR TITLE
Fix M1600 axle group clear spacings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ the project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Correct M1600 inter-group axle spacings to AS 5100.2:2017 Figure 7.2.4.
+  The variable middle gap and final 5 m gap are measured from the preceding
+  group's last axle; previously both were shortened by 2.5 m in SI output.
+  The minimum-gap vehicle now spans 25 m instead of 20 m. Previously generated
+  M1600 load effects will change and should be recalculated.
+- Convert the M1600 variable gap and transverse wheel track with the remaining
+  geometry for imperial output.
+
+### Changed
+- M1600 `gap` defaults to 6.25 m and rejects non-finite or smaller values.
+  It specifies the clear distance in metres, including for imperial output;
+  larger gaps remain available for adverse-load searches. The generator creates
+  axle loads only; users must add the lane UDL and applicable design factors.
+
 ---
 
 ## [0.5.0] — 2026-03-16

--- a/docs/source/pages/defining_loads.md
+++ b/docs/source/pages/defining_loads.md
@@ -16,6 +16,42 @@ Figure 1 shows the flowchart for the load module of *ospgrillage*.
 
 ## Load types
 
+### M1600 axle model
+
+```python
+vehicle = og.create_load_model(model_type="M1600", gap=6.25).create()
+```
+
+`gap` is the **clear distance from the last axle of the second tri-axle
+group to the first axle of the third**, in metres. AS 5100.2:2017
+Figure 7.2.4 specifies a minimum of 6.25 m. This is variable spacing:
+investigate larger gaps as well as longitudinal and transverse positions
+to obtain the most adverse load effect. The generator does not perform
+that search. The argument is in metres even for imperial output.
+
+At the minimum gap, the twelve axle coordinates relative to the first axle
+are:
+
+```text
+0, 1.25, 2.50, 6.25, 7.50, 8.75, 15.00, 16.25, 17.50, 22.50, 23.75, 25.00 m
+```
+
+Each axle has two 60 kN wheel point loads, 2 m apart. The returned compound
+load contains these 24 points only. Add the accompanying **6 kN/m lane UDL**
+over the 3.2 m design lane separately, with adverse loaded lengths, dynamic
+allowance, accompanying-lane factors and the required load combinations.
+
+For a useful independent check, translate the minimum-gap axle train over
+the midspan influence line of a 30 m simply supported span. The maximum
+unfactored axle moment is 5,250 kNm; the full-span lane UDL adds 675 kNm.
+Applying an illustrative full-M1600 DLA of 0.3 and ULS factor of 1.8 gives
+13,864.5 kNm for that single lane, before transverse distribution.
+
+Earlier versions shortened both the middle and final inter-group gaps by
+2.5 m in SI output. Recalculate results produced using that generator.
+
+### Vertices and individual loads
+
 Every load in *ospgrillage* is built from two things:
 
 1. **A load vertex** — `LoadVertex(x, y, z, p)` is a `namedtuple` that says *where* a load acts and *how much*. `x`, `y`, `z` are global coordinates and `p` is the load magnitude. The meaning of `p` depends on the load type (force, force/length, or force/area — see below). For grillage models, `y = 0` (the deck plane) almost always.

--- a/src/ospgrillage/load.py
+++ b/src/ospgrillage/load.py
@@ -1539,11 +1539,15 @@ class LoadModel:
 
     """
 
-    def __init__(self, gap=0, **kwargs):
+    def __init__(self, gap=6.25, **kwargs):
         """
         Init the class.
 
-        :param gap: Gap between axles (specific to M1600 load model). Defaults to ``0``.
+        :param gap: M1600 clear distance in metres from the last axle of the
+            second tri-axle group to the first axle of the third group.
+            Defaults to the minimum ``6.25``; vary this distance and the
+            vehicle position to obtain the most adverse load effect.
+            Specified in metres even when output ``units`` are imperial.
         :type gap: float or int
         :param model_type: Load model type identifier.
         :type model_type: str, optional
@@ -1590,6 +1594,9 @@ class LoadModel:
         Notes
         -----
         Currently supports "M1600" (Australian Standard AS5100).
+        The M1600 generator supplies the 24 wheel point loads only. Add the
+        6 kN/m lane UDL separately, with the required positioning, dynamic
+        allowance, accompanying-lane factors and load combinations.
         Additional load models can be added by implementing new create_* methods.
         """
         if self.model_type == "M1600":
@@ -1597,11 +1604,28 @@ class LoadModel:
 
     def create_m1600_vehicle(self, gap):
         """
-        AS5100 Australian load model.
+        Create the M1600 axle loads from AS 5100.2:2017 Figure 7.2.4.
 
-        :param gap: Gap between axle group
-        :returns: :class:`~ospgrillage.load.CompoundLoad` object of a M1600 vehicle in local coordinate.
+        Parameters
+        ----------
+        gap : float
+            Clear distance in metres from the last axle of group 2 to the
+            first axle of group 3. Must be finite and at least 6.25 m.
+            This is variable spacing, not an increment above the minimum.
+
+        Returns
+        -------
+        CompoundLoad
+            Twenty-four wheel point loads, with the configured origin.
+            The accompanying lane UDL and design factors are not included.
+
+        Raises
+        ------
+        ValueError
+            If the clear gap is non-finite or less than 6.25 m.
         """
+        if not np.isfinite(gap) or gap < 6.25:
+            raise ValueError("M1600 gap must be finite and at least 6.25 m")
         # default SI units
         m = 1
         kN = 1e3
@@ -1616,23 +1640,20 @@ class LoadModel:
         left_group_dist = 3.75 * m * ft_convert
         right_group_dist = 5 * m * ft_convert
         wheel_load = 60 * kN * ton_convert
+        # Figure dimensions are clear distances between adjacent groups,
+        # measured from the LAST axle of one to the FIRST of the next.
+        group_length = 2 * axle_dist
+        group_2_start = group_length + left_group_dist
+        group_3_start = group_2_start + group_length + gap * m * ft_convert
+        group_4_start = group_3_start + group_length + right_group_dist
         load_positions_x = [
-            0,
-            axle_dist,
-            axle_dist * 2,
-            left_group_dist + axle_dist * 2,
-            left_group_dist + axle_dist * 2 + axle_dist,
-            left_group_dist + axle_dist * 2 + 2 * axle_dist,
-            gap + left_group_dist + axle_dist * 2,
-            gap + left_group_dist + axle_dist * 2 + axle_dist,
-            gap + left_group_dist + axle_dist * 2 + 2 * axle_dist,
-            right_group_dist + gap + left_group_dist + axle_dist * 2,
-            right_group_dist + gap + left_group_dist + axle_dist * 2 + axle_dist,
-            right_group_dist + gap + left_group_dist + axle_dist * 2 + 2 * axle_dist,
+            group_start + axle * axle_dist
+            for group_start in (0, group_2_start, group_3_start, group_4_start)
+            for axle in range(3)
         ]
         load_positions_x = [point + self.x_offset for point in load_positions_x]
 
-        load_positions_z = [-1, 1]
+        load_positions_z = [-m * ft_convert, m * ft_convert]
         load_positions_z = [point + self.z_offset for point in load_positions_z]
 
         M1600_vehicle = create_compound_load(name="M1600 Vehicle")

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1,6 +1,4 @@
-"""
-
-"""
+""" """
 
 from fixtures import *
 
@@ -1295,7 +1293,7 @@ def test_path_get_custom_path_points_returns_correct_length():
 
 def test_load_model_m1600_creates_compound_load():
     """LoadModel.create() for M1600 must return a CompoundLoad with 24 point loads."""
-    lm = og.LoadModel(model_type="M1600", gap=5.0)
+    lm = og.LoadModel(model_type="M1600", gap=6.25)
     vehicle = lm.create()
     assert vehicle is not None
     assert len(vehicle.compound_load_obj_list) == 24
@@ -1303,7 +1301,7 @@ def test_load_model_m1600_creates_compound_load():
 
 def test_load_model_m1600_non_zero_loads():
     """All M1600 point loads must have a non-zero p value."""
-    lm = og.LoadModel(model_type="M1600", gap=5.0)
+    lm = og.LoadModel(model_type="M1600", gap=6.25)
     vehicle = lm.create()
     for point_load in vehicle.compound_load_obj_list:
         assert point_load.load_point_1.p > 0
@@ -1411,6 +1409,8 @@ def test_dkt_triangle_shape_function_centroid_partition_and_equilibrium():
     assert np.isclose(sum(Nv), 1.0)
     assert np.isclose(sum(Nmx), 0.0)
     assert np.isclose(sum(Nmz), 0.0)
+
+
 def test_dkt_triangle_shape_function_matches_1d_hermite_on_edge():
     """On a triangle edge, the DKT distributor should reduce to the 1D Hermite beam form."""
     Nv, Nmx, Nmz = og.ShapeFunction.dkt_triangle_shape_function(
@@ -1450,9 +1450,7 @@ def test_dkt_triangle_shape_function_reproduces_linear_fields():
 
     nodal_w = [a * x1 + b * z1 + c, a * x2 + b * z2 + c, a * x3 + b * z3 + c]
     interpolated_w = (
-        sum(n * w for n, w in zip(Nv, nodal_w))
-        + a * sum(Nmz)
-        + b * sum(Nmx)
+        sum(n * w for n, w in zip(Nv, nodal_w)) + a * sum(Nmz) + b * sum(Nmx)
     )
 
     assert np.isclose(interpolated_w, a * x + b * z + c)
@@ -1477,7 +1475,9 @@ def test_hermite_triangle_region_uses_dkt_style_distribution(bridge_model_42_neg
         sum(coord[2] for coord in coords) / 3,
     ]
 
-    load_cmd = bridge._assign_load_to_four_node(point=point, mag=1.0, shape_func="hermite")
+    load_cmd = bridge._assign_load_to_four_node(
+        point=point, mag=1.0, shape_func="hermite"
+    )
 
     assert len(load_cmd) == 3
     vertical_sum = sum(command[1][2] for command in load_cmd)

--- a/tests/test_m1600.py
+++ b/tests/test_m1600.py
@@ -1,0 +1,135 @@
+"""M1600 geometry and an independent simply supported influence-line benchmark.
+
+Geometry: AS 5100.2:2017 Figure 7.2.4. The 30 m midspan example is
+also worked in CIV4280/CIV5170, BridgeLoading, ex:m1600midspan.
+"""
+
+import numpy as np
+import pytest
+
+import ospgrillage as og
+
+
+def vertices(vehicle):
+    return [load.load_point_1 for load in vehicle.compound_load_obj_list]
+
+
+@pytest.mark.parametrize("gap", [6.25, 8.75, 15.0, 30.0])
+def test_m1600_clear_group_spacings(gap):
+    points = vertices(og.create_load_model(model_type="M1600", gap=gap).create())
+    x = np.unique([p.x for p in points])
+    # Dimensions between successive axles, read directly from Figure 7.2.4.
+    np.testing.assert_allclose(
+        np.diff(x), [1.25, 1.25, 3.75, 1.25, 1.25, gap, 1.25, 1.25, 5, 1.25, 1.25]
+    )
+    assert len(points) == 24
+    assert sum(p.p for p in points) == pytest.approx(1440e3)
+    assert sorted({p.z for p in points}) == [-1, 1]
+    assert all(p.p == 60e3 for p in points)
+
+
+def test_m1600_default_is_minimum_clear_gap():
+    points = vertices(og.create_load_model(model_type="M1600").create())
+    np.testing.assert_allclose(
+        np.unique([p.x for p in points]),
+        [0, 1.25, 2.5, 6.25, 7.5, 8.75, 15, 16.25, 17.5, 22.5, 23.75, 25],
+    )
+
+
+@pytest.mark.parametrize("gap", [0, -1, 5.0, 6.249, np.nan, np.inf, -np.inf])
+def test_m1600_rejects_invalid_clear_gap(gap):
+    with pytest.raises(ValueError, match="gap"):
+        og.create_load_model(model_type="M1600", gap=gap).create()
+
+
+def test_m1600_direct_generator_rejects_invalid_gap():
+    with pytest.raises(ValueError, match="gap"):
+        og.LoadModel(model_type="M1600").create_m1600_vehicle(0)
+
+
+def test_m1600_gap_and_wheel_track_convert_with_geometry():
+    origin = og.Point(10, 0, 20)
+    points = vertices(
+        og.create_load_model(
+            model_type="M1600", gap=10, units="imperial", origin=origin
+        ).create()
+    )
+    x = np.unique([p.x for p in points])
+    np.testing.assert_allclose(
+        np.diff(x) / 3.28084,
+        [1.25, 1.25, 3.75, 1.25, 1.25, 10, 1.25, 1.25, 5, 1.25, 1.25],
+    )
+    assert x[0] == pytest.approx(origin.x)
+    np.testing.assert_allclose(
+        sorted({p.z for p in points}), [20 - 3.28084, 20 + 3.28084]
+    )
+
+
+def test_m1600_30m_midspan_influence_line():
+    points = vertices(og.create_load_model(model_type="M1600", gap=6.25).create())
+    x = np.array([p.x for p in points])
+    loads = np.array([p.p for p in points])
+    # The response is piecewise linear in translation. Its exact maximum
+    # occurs when an axle crosses a support or the midspan influence-line peak.
+    shifts = np.unique(np.concatenate([-x, 15 - x, 30 - x]))
+    positions = shifts[:, None] + x
+    ordinates = np.where(
+        (positions >= 0) & (positions <= 30),
+        np.minimum(positions, 30 - positions) / 2,
+        0,
+    )
+    axle_moment = np.max(ordinates @ loads)
+    lane_udl_moment = 6e3 * 30**2 / 8
+    assert axle_moment == pytest.approx(5250e3)
+    assert axle_moment + lane_udl_moment == pytest.approx(5925e3)
+    assert 1.8 * 1.3 * (axle_moment + lane_udl_moment) == pytest.approx(13864.5e3)
+
+
+def test_m1600_30m_grillage_recovers_total_midspan_moment():
+    """Run the generated wheel loads through OpenSees and sum girder moments."""
+    material = og.create_material(E=30e9, G=12.5e9, rho=2400)
+    section = og.create_section(A=1, Iz=1, Iy=1, J=0.1)
+    member = og.create_member(section=section, material=material)
+    grid = og.create_grillage(
+        bridge_name="M1600 benchmark",
+        long_dim=30,
+        width=4,
+        skew=0,
+        num_long_grid=5,
+        num_trans_grid=7,
+        edge_beam_dist=1,
+        mesh_type="Ortho",
+    )
+    for name in (
+        "edge_beam",
+        "exterior_main_beam_1",
+        "interior_main_beam",
+        "exterior_main_beam_2",
+        "transverse_slab",
+        "start_edge",
+        "end_edge",
+    ):
+        grid.set_member(member, member=name)
+    grid.create_osp_model(pyfile=False)
+    # Axle 6 at midspan gives the independent influence-line maximum.
+    vehicle = og.create_load_model(
+        model_type="M1600", gap=6.25, origin=og.Point(6.25, 0, 2)
+    ).create()
+    case = og.create_load_case(name="M1600 axles")
+    case.add_load(vehicle)
+    grid.add_load_case(case)
+    grid.analyze()
+    results = grid.get_results()
+    nodes = grid.get_nodes()
+    moments = []
+    for element in results.Element.values:
+        node_i, node_j = results.ele_nodes.sel(Element=element).values
+        start = nodes[int(node_i)]["coordinate"]
+        end = nodes[int(node_j)]["coordinate"]
+        if np.isclose(start[0], 15) and end[0] > start[0]:
+            moments.append(
+                float(results.forces.sel(Element=element, Component="Mz_i").item())
+            )
+    assert len(moments) == 5
+    assert np.all(np.isfinite(moments))
+    assert abs(sum(moments)) == pytest.approx(5250e3, rel=1e-8)


### PR DESCRIPTION
`create_load_model(model_type="M1600", gap=6.25).create()` generated a 20 m axle train instead of the 25 m configuration in AS 5100.2:2017 Figure 7.2.4. The middle and final inter-group spacings were measured from the preceding group's first axle instead of its last, shortening both clear distances by 2.5 m in SI output.

The generator now constructs each group from the end of the previous one. `gap` is explicitly the variable clear distance from the last axle of group 2 to the first axle of group 3, in metres: it defaults to 6.25 m, accepts larger values for adverse-load searches, and rejects smaller/non-finite values. The variable gap and wheel track now convert with the rest of the geometry for imperial output.

At minimum gap the axle coordinates are:

```text
0, 1.25, 2.5, 6.25, 7.5, 8.75, 15, 16.25, 17.5, 22.5, 23.75, 25 m
```

The discrepancy was identified by comparing the generator with the CIV4280/CIV5170 course calculator, then visually checking the standard's dimension chain. An independent 30 m simply supported midspan influence-line calculation gives 5,250 kNm from the corrected axle train, versus 6,525 kNm before the fix. The 6 kN/m lane UDL adds 675 kNm; the example's 1.8 × 1.3 factors give 13,864.5 kNm for one lane. The fixed-gap benchmark does not replace searching variable gaps and lane arrangements.

Documentation and changelog describe the corrected gap contract, the need to recalculate earlier generated load effects, and the fact that the factory supplies axle point loads only: the lane UDL, DLA, accompanying-lane factors and combinations remain the caller's responsibility. The old error is not assumed conservative for other spans or load effects.

Validation:

- 15 new parameterized regression cases failed on unmodified upstream `main`, covering dimension chains, minimum/default gap, invalid gaps, imperial geometry and the independent influence-line result.
- All 16 new cases pass after the fix, including an actual OpenSees grillage analysis whose summed midspan girder moments recover 5,250 kNm.
- Full test suite: **209 passed**, one existing open-figure warning (Python 3.13).
- Strict Sphinx HTML build passes with `-W --keep-going -D nbsphinx_execute=never`; existing notebook outputs were not regenerated.
- Black checks pass for all changed Python files; `git diff --check` passes.

This changes results from the existing factory and rejects previously accepted gaps below the standard minimum. Code using custom sub-minimum axle arrangements should construct a `CompoundLoad` explicitly.
